### PR TITLE
Token truncation fix

### DIFF
--- a/trust-drops-ui/src/pages/Dashboard.jsx
+++ b/trust-drops-ui/src/pages/Dashboard.jsx
@@ -254,7 +254,7 @@ function Dashboard() {
         return {
           address: data.candidate.id,
           stake: truncateAmount(data.amount, 2),
-          credibility: truncateAmount(data.credScore, 2),
+          credibility: data.credScore,
         };
       });
     } catch (err) {
@@ -286,7 +286,7 @@ function Dashboard() {
         return {
           address: data.staker.id,
           received: truncateAmount(data.amount, 2),
-          credibilityGained: truncateAmount(data.credScore, 2),
+          credibilityGained: data.credScore,
         };
       });
     } catch (err) {

--- a/trust-drops-ui/src/pages/Dashboard.jsx
+++ b/trust-drops-ui/src/pages/Dashboard.jsx
@@ -140,6 +140,8 @@ function Dashboard() {
     while (decimal && decimal.length < precision) {
       decimal += '0';
     }
+    decimal = decimal.substring(0, precision);
+
     return `${whole}.${decimal}`;
   };
 
@@ -305,7 +307,14 @@ function Dashboard() {
       }
     });
 
-    console.log("finalStakesData - ", typeof(finalStakesData))
+    finalStakesData['test'] = {
+      stake: truncateAmount("10000000000000000000"),
+      credibility: truncateAmount("10990000000000000000"),
+      received: truncateAmount("10999999000000000000"),
+      credibilityGained: truncateAmount("109999990000000000"),
+    };
+
+    console.log("finalStakesData - ", finalStakesData)
 
     setUserStakesData(finalStakesData);
   }

--- a/trust-drops-ui/src/pages/Dashboard.jsx
+++ b/trust-drops-ui/src/pages/Dashboard.jsx
@@ -306,14 +306,7 @@ function Dashboard() {
         finalStakesData[el.address].credibilityGained = el.credibilityGained;
       }
     });
-
-    finalStakesData['test'] = {
-      stake: truncateAmount("10000000000000000000"),
-      credibility: truncateAmount("10990000000000000000"),
-      received: truncateAmount("10999999000000000000"),
-      credibilityGained: truncateAmount("109999990000000000"),
-    };
-
+    
     console.log("finalStakesData - ", finalStakesData)
 
     setUserStakesData(finalStakesData);

--- a/trust-drops-ui/src/pages/Dashboard.jsx
+++ b/trust-drops-ui/src/pages/Dashboard.jsx
@@ -132,9 +132,15 @@ function Dashboard() {
       ? `${address.substring(0, 4)}...${address.substring(address.length - 4)}`
       : address;
   };
-  const truncateAmount = (amount) => {
+  const truncateAmount = (amount, precision=4) => {
     const formattedAmount = ethers.utils.formatUnits(amount);
-    return (+formattedAmount).toFixed(4);
+    let [whole, decimal] = formattedAmount.split('.');
+    // toFixed will add imprecision to the number in some cases (parseFloat("1.9999").toFixed(18)),
+    // so we manually pad the number
+    while (decimal && decimal.length < precision) {
+      decimal += '0';
+    }
+    return `${whole}.${decimal}`;
   };
 
   const copyToClipboard = async (wallet) => {
@@ -245,8 +251,8 @@ function Dashboard() {
       stakesData = data.data.stakes.toReversed().map((data) => {
         return {
           address: data.candidate.id,
-          stake: parseFloat(ethers.utils.formatUnits(data.amount)).toFixed(2),
-          credibility: parseFloat(data.credScore).toFixed(2),
+          stake: truncateAmount(data.amount, 2),
+          credibility: truncateAmount(data.credScore, 2),
         };
       });
     } catch (err) {
@@ -277,10 +283,8 @@ function Dashboard() {
       receivedData = data.data.stakes.toReversed().map((data) => {
         return {
           address: data.staker.id,
-          received: parseFloat(ethers.utils.formatUnits(data.amount)).toFixed(
-            2
-          ),
-          credibilityGained: parseFloat(data.credScore).toFixed(2),
+          received: truncateAmount(data.amount, 2),
+          credibilityGained: truncateAmount(data.credScore, 2),
         };
       });
     } catch (err) {
@@ -288,7 +292,7 @@ function Dashboard() {
     }
 
     let finalStakesData = {};
-    stakesData.concat(receivedData).map(el => {
+    (stakesData || []).concat((receivedData || [])).map(el => {
       if (!finalStakesData[el.address]) finalStakesData[el.address] = {address: el.address};
       
       if (el.credibility) {


### PR DESCRIPTION
Issue https://github.com/mande-labs/mande-chain/issues/45

This Pull Request changes the handling of number formatting in Dashboard.jsx, because there were a couple of cases where the number wouldn't show enough details for user to be able to destake correct amount of tokens.

Functional changes:

| Input | Previous Output | New Output |
|--|--|--|
| 2.00 | 2.00 | 2.00 |
| 2 | 2.00 | 2.00 |
| 2.1 | 2.10 | 2.00 |
| 1.99 | 1.99 | 1.99 |
| 1.99999 | **2.00** | **1.99** |
| 1.9999900000 | **2.00** | **1.99** |

Other important thing (also mentioned in comment as it's not immediately obvious), `toFixed` is not used to pad the length because of the way javascript handles floating point numbers.